### PR TITLE
modify javadoc - change one character, add 2 javadocs

### DIFF
--- a/cours6/interface.h
+++ b/cours6/interface.h
@@ -1,3 +1,6 @@
+// Types
+// -----
+
 typedef void * Definition;
 typedef struct dictionnaire * Dictionnaire;
 typedef enum statut {OK,
@@ -5,6 +8,11 @@ typedef enum statut {OK,
                      ERR_INSERE_ENTREE_EXISTANTE,
                      ERR_DICTIONNAIRE_VIDE} Statut;
 
+/**
+ * Cree une dictionnaire vide et la retourne.
+ *
+ * @returns  La dictionnaire vide
+ */
 Dictionnaire dictionnaireCreer();
 Dictionnaire dictionnaireInsereEntree
              (struct dictionnaire *, char *, void *);

--- a/cours6/interface.h
+++ b/cours6/interface.h
@@ -14,8 +14,20 @@ typedef enum statut {OK,
  * @returns  La dictionnaire vide
  */
 Dictionnaire dictionnaireCreer();
+
+/**
+ * Ajoute un element sur le dessus de la dictionnaire.
+ *
+ * Although we don't need to give names for the parameters, 
+ *   it is better to give so that we can document down the usage in the javadoc.
+ *
+ * @param (dictionnaire)   Un pointeur vers la dictionnaire
+ * @param (char)           ?
+ * @param (void)           ?
+ */
 Dictionnaire dictionnaireInsereEntree
              (struct dictionnaire *, char *, void *);
+
 int          dictionnaireSupprimerEntree
              (char *, Definition *, Dictionnaire *);
 Statut       dictionnaireLitEntree

--- a/cours9/cunit/treemap.h
+++ b/cours9/cunit/treemap.h
@@ -43,7 +43,7 @@ char *treemapGet(const TreeMap *t, char *key);
 void treemapSet(TreeMap *t, char *key, char *value);
 
 /**
- * Retourne vrai si et seulement si la cle apparaît dans la table.
+ * Retourne vrai si et seulement si la cle apparait dans la table.
  *
  * @param t    La table associative
  * @param key  La cle a rechercher


### PR DESCRIPTION
1. change **apparaît** to **apparait**

Because in all of your other javadoc, you don't use accents. It is for harmonizing your documentation to use same style. Plus, accent characters may not appear correctly in certain computer settings.

2. add javadoc to 2 prototypes. First one was okay. But the second one was confusing because you did not provide names for the parameters. But I still tried to write down something.